### PR TITLE
Bump decompress-zip to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "async": "^0.9.0",
     "wrench": "^1.5.8",
     "progress": "^1.1.5",
-    "decompress-zip": "0.0.6"
+    "decompress-zip": "^0.2.0"
   },
   "keywords": [
     "electron app builder electron-builder electron-app-builder"


### PR DESCRIPTION
While trying to build, we get the following error:

```
$ grunt build-electron-app
Running "build-electron-app" task

Downloading releases...
Downloading electron for linux64
[====================] 100% 0.0s

Extracting releases...
>> Extracting linux64
>> Error: Could not find the End of Central Directory Record
```

This is solved by using the latest release of decompress-zip, currently 0.2.0.
