### PR TITLE
Allow to specify a list of files instead of a single directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "async": "^0.9.0",
     "wrench": "^1.5.8",
     "progress": "^1.1.5",
-    "decompress-zip": "^0.2.0"
+    "decompress-zip": "0.0.6",
+    "glob": "^5.0.14"
   },
   "keywords": [
     "electron app builder electron-builder electron-app-builder"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "async": "^0.9.0",
     "wrench": "^1.5.8",
     "progress": "^1.1.5",
-    "decompress-zip": "0.0.6"
+    "decompress-zip": "^0.2.0"
   },
   "keywords": [
     "electron app builder electron-builder electron-app-builder"


### PR DESCRIPTION
New option added: "app_files". When this options is present, "app_dir" is ignored.
This option accepts an array containing a list of files to be included in the app.
Patterns are allowed, following the standard [glob syntax](https://github.com/isaacs/node-glob).

An example configuration would be:

``` javascript
module.exports = function(grunt) {
  grunt.initConfig({
    'build-electron-app': {
        options: {
            platforms: ["darwin", "win32"],
            app_files: [
              // Include
              './app/**',
              './node_modules/**',
              './package.json',

              // Exclude
              '!./node_modules/*grunt*/**',
              '!./**/test*/**'
            ]
        }
    }
  });
  grunt.loadNpmTasks('grunt-electron-app-builder');
};
```
